### PR TITLE
Added type in invokeMapMethod

### DIFF
--- a/lib/mercado_pago_mobile_checkout.dart
+++ b/lib/mercado_pago_mobile_checkout.dart
@@ -33,7 +33,8 @@ class MercadoPagoMobileCheckout {
     String publicKey,
     String preferenceId,
   ) async {
-    Map<String, dynamic> result = await (_channel.invokeMapMethod(
+    Map<String, dynamic> result =
+        await (_channel.invokeMapMethod<String, dynamic>(
       'startCheckout',
       {
         "publicKey": publicKey,


### PR DESCRIPTION
The following error occurred when calling startCheckout, resolved by adding the type of the map to be returned in invokeMapMethod

Exception has occurred.
_CastError (type 'Future<Map<dynamic, dynamic>?>' is not a subtype of type 'FutureOr<Map<String, dynamic>>' in type cast)