### PR TITLE
feat: upgrade version of com.mercadopago.android.px:checkout to 4.53.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,5 +46,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.mercadopago.android.px:checkout:4.53.+'
+    implementation 'com.mercadopago.android.px:checkout:4.53.2'
 }


### PR DESCRIPTION
force upgrade to com.mercadopago.android.px:checkout:4.53.2
fix #54